### PR TITLE
Fix a downsampling error.

### DIFF
--- a/bin/DownsampleToCoverage.py
+++ b/bin/DownsampleToCoverage.py
@@ -142,7 +142,8 @@ def GetReads(Ranges, Depths, RefFile, Target, Seed):
                     prev_end = overSeq[2] + 1
                 elif overSeq[0] != prev_name:
                     end = infile.get_reference_length(prev_name)
-                    keep += list(infile.fetch(prev_name, prev_end, end))
+                    if end > prev_end:
+                        keep += list(infile.fetch(prev_name, prev_end, end))
                     prev_end = 1
                     prev_name = overSeq[0]
                     if overSeq[1] > prev_end:


### PR DESCRIPTION
This error occurs if the end of a segment is over the MaxCoverage. The position to grab the last reads from is increased by 1 after what turns out to be the end of the segment and produces an index error.